### PR TITLE
Added support of protocol 'aurora' to allow master to be selected for connection

### DIFF
--- a/src/main/java/technology/dice/dicefairlink/driver/AuroraReadDriver.java
+++ b/src/main/java/technology/dice/dicefairlink/driver/AuroraReadDriver.java
@@ -241,7 +241,7 @@ public class AuroraReadDriver implements Driver {
     }
     String delegate = matcher.group("delegate");
     LOGGER.log(Level.FINE, "Delegate driver: {0}", delegate);
-    final String clusterURI = protocolName + ":" + matcher.group("uri");
+    final String clusterURI = delegate + ":" + matcher.group("uri");
     try {
       URI uri = new URI(clusterURI);
       LOGGER.log(Level.FINE, "Driver URI: {0}", uri);

--- a/src/main/java/technology/dice/dicefairlink/driver/AuroraReadDriver.java
+++ b/src/main/java/technology/dice/dicefairlink/driver/AuroraReadDriver.java
@@ -58,6 +58,7 @@ public class AuroraReadDriver implements Driver {
   private final Map<String, Driver> delegates = new HashMap<>();
   private final Map<URI, AuroraReadEndpoint> auroraClusters = new HashMap<>();
 
+  private final String protocolName;
   private final Pattern driverPattern;
   private final Predicate<DBClusterMember> allowedMembersPredicate;
   private final ScheduledExecutorService executor;
@@ -74,7 +75,8 @@ public class AuroraReadDriver implements Driver {
 
   public AuroraReadDriver(final String protocolName, final Predicate<DBClusterMember> allowedMembersPredicate, final ScheduledExecutorService executor) {
     LOGGER.fine("Starting...");
-    this.driverPattern = Pattern.compile("jdbc:" + protocolName + ":(?<delegate>[^:]*):(?<uri>.*\\/\\/.+)");
+    this.protocolName = protocolName;
+    this.driverPattern = Pattern.compile("jdbc:" + this.protocolName + ":(?<delegate>[^:]*):(?<uri>.*\\/\\/.+)");
     this.allowedMembersPredicate = allowedMembersPredicate;
     this.executor = executor;
   }
@@ -239,7 +241,7 @@ public class AuroraReadDriver implements Driver {
     }
     String delegate = matcher.group("delegate");
     LOGGER.log(Level.FINE, "Delegate driver: {0}", delegate);
-    final String clusterURI = DRIVER_PROTOCOL_RO + ":" + matcher.group("uri");
+    final String clusterURI = protocolName + ":" + matcher.group("uri");
     try {
       URI uri = new URI(clusterURI);
       LOGGER.log(Level.FINE, "Driver URI: {0}", uri);

--- a/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverConnectAlternatingListTest.java
+++ b/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverConnectAlternatingListTest.java
@@ -58,7 +58,7 @@ public class AuroraReadReplicasDriverConnectAlternatingListTest {
     Regions.class,
     AmazonRDSAsyncClient.class,
     AmazonRDSAsyncClientBuilder.class,
-    AuroraReadReplicasDriver.class
+    AuroraReadDriver.class
   })
   public void canConnectToValidUrlBasicAuth_thenListOfReplicasChanges() throws Exception {
     final String stubInstanceId_A = "123";
@@ -93,7 +93,9 @@ public class AuroraReadReplicasDriverConnectAlternatingListTest {
     final Driver mockDriver = mock(Driver.class);
 
     PowerMock.mockStatic(DriverManager.class);
-    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadReplicasDriver.class));
+    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadDriver.class));
+    PowerMock.expectLastCall();
+    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadDriver.class));
     PowerMock.expectLastCall();
     EasyMock.expect(DriverManager.getDriver(VALID_LOW_JDBC_URL_A)).andReturn(mockDriver);
     EasyMock.expect(DriverManager.getDriver(VALID_LOW_JDBC_URL_B)).andReturn(mockDriver);
@@ -151,8 +153,8 @@ public class AuroraReadReplicasDriverConnectAlternatingListTest {
     Mockito.when(mockEndpoint_C.getAddress()).thenReturn(VALID_ENDPOINT_ADDRESS_C);
 
     final StepByStepExecutor stepByStepExecutor = new StepByStepExecutor(1);
-    AuroraReadReplicasDriver auroraReadReplicasDriver =
-        new AuroraReadReplicasDriver(stepByStepExecutor);
+    AuroraReadDriver auroraReadReplicasDriver =
+        new AuroraReadDriver(AuroraReadDriver.DRIVER_PROTOCOL_RO, AuroraReadDriver.ONLY_READ_REPLICAS, stepByStepExecutor);
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, validProperties);
     stepByStepExecutor.step();
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, validProperties);

--- a/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverConnectAlternatingWithMasterTest.java
+++ b/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverConnectAlternatingWithMasterTest.java
@@ -6,6 +6,7 @@
 package technology.dice.dicefairlink.driver;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -38,16 +39,19 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import technology.dice.dicefairlink.driver.AuroraReadReplicasDriverConnectTest.StepByStepExecutor;
 
 @RunWith(PowerMockRunner.class)
-public class AuroraReadReplicasDriverConnectSameListTest {
+public class AuroraReadReplicasDriverConnectAlternatingWithMasterTest {
 
   private static final String VALID_JDBC_URL =
-      "jdbc:auroraro:mysql://aa:123/db?param1=123&param2=true&param3=abc";
+      "jdbc:aurora:mysql://aa:123/db?param1=123&param2=true&param3=abc";
   private static final String VALID_LOW_JDBC_URL_A =
       "jdbc:mysql://replica-1-ro:123/db?param1=123&param2=true&param3=abc";
   private static final String VALID_LOW_JDBC_URL_B =
       "jdbc:mysql://replica-2-ro:123/db?param1=123&param2=true&param3=abc";
+  private static final String VALID_LOW_JDBC_URL_C =
+      "jdbc:mysql://master:123/db?param1=123&param2=true&param3=abc";
   private static final String VALID_ENDPOINT_ADDRESS_A = "replica-1-ro";
   private static final String VALID_ENDPOINT_ADDRESS_B = "replica-2-ro";
+  private static final String VALID_ENDPOINT_ADDRESS_C = "master";
 
   @Test
   @PrepareForTest({
@@ -57,9 +61,10 @@ public class AuroraReadReplicasDriverConnectSameListTest {
     AmazonRDSAsyncClientBuilder.class,
     AuroraReadDriver.class
   })
-  public void canConnectToValidUrlBasicAuth() throws Exception {
+  public void canConnectToValidUrlBasicAuth_thenListOfReplicasChanges() throws Exception {
     final String stubInstanceId_A = "123";
     final String stubInstanceId_B = "345";
+    final String stubInstanceId_C = "567";
 
     final Properties validProperties = new Properties();
     validProperties.put("replicaPollInterval", "1");
@@ -76,12 +81,16 @@ public class AuroraReadReplicasDriverConnectSameListTest {
     final DBCluster mockDbCluster = mock(DBCluster.class);
     final DBClusterMember mockDbClusterMember_A = mock(DBClusterMember.class);
     final DBClusterMember mockDbClusterMember_B = mock(DBClusterMember.class);
+    final DBClusterMember mockDbClusterMember_C = mock(DBClusterMember.class);
     final DescribeDBInstancesResult mockDbInstancesResult_A = mock(DescribeDBInstancesResult.class);
     final DescribeDBInstancesResult mockDbInstancesResult_B = mock(DescribeDBInstancesResult.class);
+    final DescribeDBInstancesResult mockDbInstancesResult_C = mock(DescribeDBInstancesResult.class);
     final DBInstance mockDbInstance_A = mock(DBInstance.class);
     final DBInstance mockDbInstance_B = mock(DBInstance.class);
+    final DBInstance mockDbInstance_C = mock(DBInstance.class);
     final Endpoint mockEndpoint_A = mock(Endpoint.class);
     final Endpoint mockEndpoint_B = mock(Endpoint.class);
+    final Endpoint mockEndpoint_C = mock(Endpoint.class);
     final Driver mockDriver = mock(Driver.class);
 
     PowerMock.mockStatic(DriverManager.class);
@@ -91,6 +100,7 @@ public class AuroraReadReplicasDriverConnectSameListTest {
     PowerMock.expectLastCall();
     EasyMock.expect(DriverManager.getDriver(VALID_LOW_JDBC_URL_A)).andReturn(mockDriver);
     EasyMock.expect(DriverManager.getDriver(VALID_LOW_JDBC_URL_B)).andReturn(mockDriver);
+    EasyMock.expect(DriverManager.getDriver(VALID_LOW_JDBC_URL_C)).andReturn(mockDriver);
     PowerMock.replay(DriverManager.class);
 
     PowerMockito.mockStatic(AmazonRDSAsyncClient.class);
@@ -108,52 +118,61 @@ public class AuroraReadReplicasDriverConnectSameListTest {
         .thenReturn(Arrays.asList(mockDbCluster));
 
     Mockito.when(mockDbCluster.getDBClusterMembers())
-        .thenReturn(Arrays.asList(mockDbClusterMember_A, mockDbClusterMember_B));
-    Mockito.when(mockDbClusterMember_A.isClusterWriter()).thenReturn(false);
-    Mockito.when(mockDbClusterMember_A.getDBInstanceIdentifier()).thenReturn(stubInstanceId_A);
+        .thenReturn(Arrays.asList(mockDbClusterMember_A, mockDbClusterMember_B))
+        .thenReturn(Arrays.asList(mockDbClusterMember_A, mockDbClusterMember_C))
+        .thenReturn(Arrays.asList(mockDbClusterMember_B, mockDbClusterMember_C));
 
-    Mockito.when(mockDbClusterMember_B.isClusterWriter()).thenReturn(false);
+    Mockito.when(mockDbClusterMember_A.getDBInstanceIdentifier()).thenReturn(stubInstanceId_A);
     Mockito.when(mockDbClusterMember_B.getDBInstanceIdentifier()).thenReturn(stubInstanceId_B);
+    Mockito.when(mockDbClusterMember_C.getDBInstanceIdentifier()).thenReturn(stubInstanceId_C);
 
     Mockito.when(
         mockAmazonRDSAsync.describeDBInstances(Mockito.any(DescribeDBInstancesRequest.class)))
         .thenReturn(mockDbInstancesResult_A)
         .thenReturn(mockDbInstancesResult_B)
         .thenReturn(mockDbInstancesResult_A)
+        .thenReturn(mockDbInstancesResult_C)
         .thenReturn(mockDbInstancesResult_B)
-        .thenReturn(mockDbInstancesResult_A)
-        .thenReturn(mockDbInstancesResult_B);
+        .thenReturn(mockDbInstancesResult_C);
     Mockito.when(mockDbInstancesResult_A.getDBInstances())
         .thenReturn(Arrays.asList(mockDbInstance_A));
     Mockito.when(mockDbInstancesResult_B.getDBInstances())
         .thenReturn(Arrays.asList(mockDbInstance_B));
+    Mockito.when(mockDbInstancesResult_C.getDBInstances())
+        .thenReturn(Arrays.asList(mockDbInstance_C));
     Mockito.when(mockDbInstance_A.getEndpoint()).thenReturn(mockEndpoint_A);
     Mockito.when(mockDbInstance_A.getDBInstanceStatus()).thenReturn("available");
     Mockito.when(mockDbInstance_B.getEndpoint()).thenReturn(mockEndpoint_B);
     Mockito.when(mockDbInstance_B.getDBInstanceStatus()).thenReturn("available");
+    Mockito.when(mockDbInstance_C.getEndpoint()).thenReturn(mockEndpoint_C);
+    Mockito.when(mockDbInstance_C.getDBInstanceStatus()).thenReturn("available");
     Mockito.when(mockEndpoint_A.getAddress()).thenReturn(VALID_ENDPOINT_ADDRESS_A);
     Mockito.when(mockEndpoint_B.getAddress()).thenReturn(VALID_ENDPOINT_ADDRESS_B);
+    Mockito.when(mockEndpoint_C.getAddress()).thenReturn(VALID_ENDPOINT_ADDRESS_C);
 
     final StepByStepExecutor stepByStepExecutor = new StepByStepExecutor(1);
     AuroraReadDriver auroraReadReplicasDriver =
-        new AuroraReadDriver(AuroraReadDriver.DRIVER_PROTOCOL_RO, AuroraReadDriver.ONLY_READ_REPLICAS, stepByStepExecutor);
+        new AuroraReadDriver(AuroraReadDriver.DRIVER_PROTOCOL_ALL, AuroraReadDriver.ALL_INSTANCES, stepByStepExecutor);
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, validProperties);
     stepByStepExecutor.step();
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, validProperties);
     stepByStepExecutor.step();
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, validProperties);
 
-    verify(mockDbClusterMember_A, times(3))
-        .isClusterWriter(); // 3 - because of: Init step + 2 execution steps in stepByStepExecutor
-    verify(mockDbClusterMember_A, times(3)).getDBInstanceIdentifier();
-    verify(mockDbInstance_A, times(3)).getEndpoint();
-    verify(mockEndpoint_A, times(3)).getAddress();
+    verify(mockDbClusterMember_A, never()).isClusterWriter();
+    verify(mockDbClusterMember_A, times(2)).getDBInstanceIdentifier();
+    verify(mockDbInstance_A, times(2)).getEndpoint();
+    verify(mockEndpoint_A, times(2)).getAddress();
 
-    verify(mockDbClusterMember_B, times(3)).isClusterWriter();
-    verify(mockDbClusterMember_B, times(3)).getDBInstanceIdentifier();
-    verify(mockDbInstance_B, times(3)).getEndpoint();
-    verify(mockEndpoint_B, times(3)).getAddress();
+    verify(mockDbClusterMember_B, never()).isClusterWriter();
+    verify(mockDbClusterMember_B, times(2)).getDBInstanceIdentifier();
+    verify(mockDbInstance_B, times(2)).getEndpoint();
+    verify(mockEndpoint_B, times(2)).getAddress();
 
-    // PowerMock.verifyAll() can not be used in this test due to non-deterministic nature of RandomisedCyclicIterator.
+    verify(mockDbClusterMember_C, never()).isClusterWriter();
+    verify(mockDbClusterMember_C, times(2)).getDBInstanceIdentifier();
+    verify(mockDbInstance_C, times(2)).getEndpoint();
+    verify(mockEndpoint_C, times(2)).getAddress();
+
   }
 }

--- a/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverConnectTest.java
+++ b/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverConnectTest.java
@@ -53,7 +53,7 @@ public class AuroraReadReplicasDriverConnectTest {
     Regions.class,
     AmazonRDSAsyncClient.class,
     AmazonRDSAsyncClientBuilder.class,
-    AuroraReadReplicasDriver.class
+    AuroraReadDriver.class
   })
   public void canConnectToValidUrlBasicAuth() throws Exception {
     final String stubInstanceId = "123";
@@ -79,7 +79,9 @@ public class AuroraReadReplicasDriverConnectTest {
 
     PowerMockito.mockStatic(AmazonRDSAsyncClient.class);
     PowerMock.mockStatic(DriverManager.class);
-    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadReplicasDriver.class));
+    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadDriver.class));
+    PowerMock.expectLastCall();
+    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadDriver.class));
     PowerMock.expectLastCall();
     EasyMock.expect(DriverManager.getDriver(VALID_LOW_JDBC_URL)).andReturn(mockDriver);
     PowerMock.replay(DriverManager.class);
@@ -107,8 +109,8 @@ public class AuroraReadReplicasDriverConnectTest {
     Mockito.when(mockEndpoint.getAddress()).thenReturn(VALID_ENDPOINT_ADDRESS);
 
     final StepByStepExecutor stepByStepExecutor = new StepByStepExecutor(1);
-    AuroraReadReplicasDriver auroraReadReplicasDriver =
-        new AuroraReadReplicasDriver(stepByStepExecutor);
+    AuroraReadDriver auroraReadReplicasDriver =
+        new AuroraReadDriver(AuroraReadDriver.DRIVER_PROTOCOL_RO, AuroraReadDriver.ONLY_READ_REPLICAS, stepByStepExecutor);
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, validProperties);
     stepByStepExecutor.step();
 

--- a/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverSimulateClusterRecoveryTest.java
+++ b/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverSimulateClusterRecoveryTest.java
@@ -52,7 +52,7 @@ public class AuroraReadReplicasDriverSimulateClusterRecoveryTest {
     Regions.class,
     AmazonRDSAsyncClient.class,
     AmazonRDSAsyncClientBuilder.class,
-    AuroraReadReplicasDriver.class
+    AuroraReadDriver.class
   })
   public void canConnectToValidUrlBasicAuth_whenOnlyMasterIsAvailableThenListOfReplicasChanges() throws Exception {
     final String stubInstanceId_A = "123";
@@ -82,7 +82,9 @@ public class AuroraReadReplicasDriverSimulateClusterRecoveryTest {
     final Driver mockMySqlDriver = mock(Driver.class);
 
     PowerMock.mockStatic(DriverManager.class);
-    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadReplicasDriver.class));
+    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadDriver.class));
+    PowerMock.expectLastCall();
+    DriverManager.registerDriver(EasyMock.anyObject(AuroraReadDriver.class));
     PowerMock.expectLastCall();
     EasyMock.expect(DriverManager.getDriver(VALID_JDBC_CLUSTER_RO_ENDPOINT_URL)).andReturn(mockMySqlDriver); // once driver is decided for the delegated URL type (be it MySQL, PostgreSQL etc) it will not change.
     PowerMock.replay(DriverManager.class);
@@ -130,8 +132,8 @@ public class AuroraReadReplicasDriverSimulateClusterRecoveryTest {
         .thenReturn(VALID_JDBC_CLUSTER_RO_ENDPOINT_URL);
 
     final StepByStepExecutor stepByStepExecutor = new StepByStepExecutor(1);
-    AuroraReadReplicasDriver auroraReadReplicasDriver =
-        new AuroraReadReplicasDriver(stepByStepExecutor);
+    AuroraReadDriver auroraReadReplicasDriver =
+        new AuroraReadDriver(AuroraReadDriver.DRIVER_PROTOCOL_RO, AuroraReadDriver.ONLY_READ_REPLICAS, stepByStepExecutor);
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, validProperties);
     stepByStepExecutor.step();
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, validProperties);

--- a/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverTest.java
+++ b/src/test/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriverTest.java
@@ -7,6 +7,7 @@ package technology.dice.dicefairlink.driver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Before;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -17,40 +18,37 @@ public class AuroraReadReplicasDriverTest {
   private static final String VALID_JDBC_URL =
       "jdbc:auroraro:mysql://aa:123/db?param1=123&param2=true&param3=abc";
 
+  private AuroraReadDriver auroraReadReplicasDriver;
+  @Before
+  public void setUp() {
+    auroraReadReplicasDriver =
+        new AuroraReadDriver(AuroraReadDriver.DRIVER_PROTOCOL_RO, AuroraReadDriver.ONLY_READ_REPLICAS, new ScheduledThreadPoolExecutor(1));
+  }
+
   @Test(expected = SQLException.class)
   public void throwsOnAcceptsURL_nullString() throws Exception {
-    AuroraReadReplicasDriver auroraReadReplicasDriver =
-        new AuroraReadReplicasDriver(new ScheduledThreadPoolExecutor(1));
     auroraReadReplicasDriver.acceptsURL(null);
   }
 
   @Test
   public void canAcceptsURL_emptyString() throws Exception {
-    AuroraReadReplicasDriver auroraReadReplicasDriver =
-        new AuroraReadReplicasDriver(new ScheduledThreadPoolExecutor(1));
     boolean retunedValue = auroraReadReplicasDriver.acceptsURL("");
     assertThat(retunedValue).isEqualTo(false);
   }
 
   @Test
   public void canAcceptsURL_validString() throws Exception {
-    AuroraReadReplicasDriver auroraReadReplicasDriver =
-        new AuroraReadReplicasDriver(new ScheduledThreadPoolExecutor(1));
     boolean retunedValue = auroraReadReplicasDriver.acceptsURL(VALID_JDBC_URL);
     assertThat(retunedValue).isEqualTo(true);
   }
 
   @Test(expected = NullPointerException.class)
   public void failToConnectToValidUrl_nullProperties() throws Exception {
-    AuroraReadReplicasDriver auroraReadReplicasDriver =
-        new AuroraReadReplicasDriver(new ScheduledThreadPoolExecutor(1));
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, null); // last call must throw
   }
 
   @Test(expected = RuntimeException.class)
   public void failToConnectToValidUrl_emptyProperties_andNoRegionAvailable() throws Exception {
-    AuroraReadReplicasDriver auroraReadReplicasDriver =
-        new AuroraReadReplicasDriver(new ScheduledThreadPoolExecutor(1));
     final Properties emptyProperties = new Properties();
     auroraReadReplicasDriver.connect(VALID_JDBC_URL, emptyProperties); // last call must throw
   }


### PR DESCRIPTION
 - Renamed AuroraReadReplicaDriver -> AuroraReadDriver
 - Renamed AuroraReadonlyEndpoint -> AuroraReadEndpoint
 - Now supports filter predicate as a constructor parameter.