### PR TITLE
Add support for AWS instance profile credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ Add the following dependency to your `pom.xml`
 
 # Driver properties
 dice-fairlink uses the AWS RDS Java SDK to obtain information about the cluster, and needs a valid authentication
-source to establish the connection. Two modes of authentication are supported: `environment` or `basic`. Depending
+source to establish the connection. Two modes of authentication are supported: `environment`, `instance` or `basic`. Depending
 on the chosen mode, different driver properties are required. This is the full list of properties:
 - `auroraClusterRegion`: the AWS region of the cluster to connect to. Mandatory unless environment variable `AWS_DEFAULT_REGION` is set. If both provided,
 the value from data source properties object has priority.
-- `auroraDiscoveryAuthMode`: `{'environment'|'basic'}`. default: `environment`
+- `auroraDiscoveryAuthMode`: `{'environment'|'basic'|'instance'}`. default: `environment`
 - `auroraDiscoveryKeyId`: the AWS key id to connect to the Aurora cluster. Mandatory if the authentication mode is `basic`.
 Ignored otherwise.
 - `auroraDiscoverKeySecret`: the AWS key secret to connect to the Aurora cluster. Mandatory if the authentication mode is `basic`.

--- a/src/main/java/technology/dice/dicefairlink/DiscoveryAuthMode.java
+++ b/src/main/java/technology/dice/dicefairlink/DiscoveryAuthMode.java
@@ -10,7 +10,8 @@ import java.util.Optional;
 
 public enum DiscoveryAuthMode {
   BASIC,
-  ENVIRONMENT;
+  ENVIRONMENT,
+  INSTANCE;
 
   public static Optional<DiscoveryAuthMode> fromStringInsensitive(String candidate) {
     return Arrays.stream(DiscoveryAuthMode.values())

--- a/src/main/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriver.java
+++ b/src/main/java/technology/dice/dicefairlink/driver/AuroraReadReplicasDriver.java
@@ -10,6 +10,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 import technology.dice.dicefairlink.AuroraReadonlyEndpoint;
@@ -167,6 +168,8 @@ public class AuroraReadReplicasDriver implements Driver {
                   AWS_BASIC_CREDENTIALS_KEY, AWS_BASIC_CREDENTIALS_SECRET));
         }
         return new AWSStaticCredentialsProvider(new BasicAWSCredentials(key, secret));
+      case INSTANCE:
+        return InstanceProfileCredentialsProvider.getInstance();
       default:
         ENVIRONMENT:
         if (LOGGER.isLoggable(Level.FINE)) {


### PR DESCRIPTION
Added an additional enum to the DiscoveryAuthMode  and a case in the driver to use AWS instance permissions.