### PR TITLE
Fix gpg signing when publishing artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
Newer versions of GPG broke reading passphrases from stdin, due to the maintainers' perceived notion of how their software should be used vs how it actually is used in real life, leading to the ecossystem around it to have to adapt and work around this backwards incompatible change.

For these new versions, when signing via Maven, `maven-gpg-plugin` needs to be at least `3.0.1` for signing to work.